### PR TITLE
kubeconfigフラグを設定していないときにpanicが発生するのを修正

### DIFF
--- a/02/podinformer/podinformer.go
+++ b/02/podinformer/podinformer.go
@@ -9,11 +9,16 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"log"
+	"os/user"
+	"path/filepath"
 	"time"
 )
 
 func main() {
-	kubeconfig := flag.String("kubeconfig", "~/.kube/config", "kubeconfig config file")
+	u, _ := user.Current()
+	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
+	// set kubeconfig flag
+	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
 	flag.Parse()
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	clientset, err := kubernetes.NewForConfig(config)

--- a/02/podinformer/podinformer.go
+++ b/02/podinformer/podinformer.go
@@ -8,17 +8,21 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 	"log"
-	"os/user"
 	"path/filepath"
 	"time"
 )
 
 func main() {
-	u, _ := user.Current()
-	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
+	var defaultKubeConfigPath string
+	if home := homedir.HomeDir(); home != "" {
+		// build kubeconfig path from $HOME dir
+		defaultKubeConfigPath = filepath.Join(home, ".kube", "config")
+	}
+
 	// set kubeconfig flag
-	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
+	kubeconfig := flag.String("kubeconfig", defaultKubeConfigPath, "kubeconfig config file")
 	flag.Parse()
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	clientset, err := kubernetes.NewForConfig(config)

--- a/02/podlist/podlist.go
+++ b/02/podlist/podlist.go
@@ -6,18 +6,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"os/user"
+	"k8s.io/client-go/util/homedir"
 	"path/filepath"
 )
 
 func main() {
-	u, _ := user.Current()
-	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
-	// set kubeconfig flag
-	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
-	flag.Parse()
+	var defaultKubeConfigPath string
+	if home := homedir.HomeDir(); home != "" {
+		// build kubeconfig path from $HOME dir
+		defaultKubeConfigPath = filepath.Join(home, ".kube", "config")
+	}
 
-	// retrieve kubeconfig
+	// set kubeconfig flag
+	kubeconfig := flag.String("kubeconfig", defaultKubeConfigPath, "kubeconfig config file")
+	flag.Parse()
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 
 	// get clientset for kubernetes resources

--- a/02/podlist/podlist.go
+++ b/02/podlist/podlist.go
@@ -6,14 +6,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"os/user"
+	"path/filepath"
 )
 
 func main() {
+	u, _ := user.Current()
+	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
 	// set kubeconfig flag
-	kubeconfig := flag.String("kubeconfig", "~/.kube/config", "kubeconfig config file")
+	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
 	flag.Parse()
 
-	// retrive kubeconfig
+	// retrieve kubeconfig
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 
 	// get clientset for kubernetes resources

--- a/02/workqueue/enqueuePod.go
+++ b/02/workqueue/enqueuePod.go
@@ -9,18 +9,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 	"k8s.io/client-go/util/workqueue"
 	"log"
-	"os/user"
 	"path/filepath"
 	"time"
 )
 
 func main() {
-	u, _ := user.Current()
-	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
+	var defaultKubeConfigPath string
+	if home := homedir.HomeDir(); home != "" {
+		// build kubeconfig path from $HOME dir
+		defaultKubeConfigPath = filepath.Join(home, ".kube", "config")
+	}
+
 	// set kubeconfig flag
-	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
+	kubeconfig := flag.String("kubeconfig", defaultKubeConfigPath, "kubeconfig config file")
 	flag.Parse()
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	clientset, err := kubernetes.NewForConfig(config)

--- a/02/workqueue/enqueuePod.go
+++ b/02/workqueue/enqueuePod.go
@@ -11,11 +11,16 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"log"
+	"os/user"
+	"path/filepath"
 	"time"
 )
 
 func main() {
-	kubeconfig := flag.String("kubeconfig", "~/.kube/config", "kubeconfig config file")
+	u, _ := user.Current()
+	defaultPath := filepath.Join(u.HomeDir, ".kube", "config")
+	// set kubeconfig flag
+	kubeconfig := flag.String("kubeconfig", defaultPath, "kubeconfig config file")
 	flag.Parse()
 	config, _ := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
# 内容
- `kubeconfig` が設定されていないときにkubeconfigの取得に失敗する問題の修正
```sh
go run podinformer.go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b409ca]

goroutine 1 [running]:
k8s.io/client-go/kubernetes.NewForConfig(0x0, 0x0, 0x1e6f32e, 0xe)
	/Users/yutachaos/go/pkg/mod/k8s.io/client-go@v11.0.0+incompatible/kubernetes/clientset.go:335 +0x3a
main.main()
	/Users/yutachaos/src/github.com/govargo/kubecontorller-book-sample-snippet/02/podinformer/podinformer.go:19 +0x110
exit status 2
```
- `kubeconfig`フラグが設定されていない場合、kubeconfigをcurrent userのhome dirを取得して、ホームディレクトリ以下の`.kube/config` を参照するように変更した。
- ディレクトリを `filepath.Join` を利用して構築するようにしました。